### PR TITLE
Allow for file reads when open in another app

### DIFF
--- a/OpenXmlPowerTools/DocumentAssembler.cs
+++ b/OpenXmlPowerTools/DocumentAssembler.cs
@@ -348,7 +348,7 @@ namespace OpenXmlPowerTools
                     int occurances = paraContents.Select((c, i) => paraContents.Substring(i)).Count(sub => sub.StartsWith("<#"));
                     if (paraContents.StartsWith("<#") && paraContents.EndsWith("#>") && occurances == 1)
                     {
-                        var xmlText = paraContents.Substring(2, paraContents.Length - 4).Trim();
+                        var xmlText = paraContents.Substring(2, paraContents.Length - 4).Trim().Replace('“', '"').Replace('”', '"');
                         XElement xml = TransformXmlTextToMetadata(te, xmlText);
                         if (xml.Name == W.p || xml.Name == W.r)
                             return xml;
@@ -693,6 +693,9 @@ namespace OpenXmlPowerTools
                     if (tableData.Count() == 0)
                         return CreateContextErrorMessage(element, "Table Select returned no data", templateError);
                     XElement table = element.Element(W.tbl);
+                    // This does not handle the case of a table without a header - don't know how to test for that...
+		    // If there was a test, the a 'has_header' variable could be set to 0 or 1 (or more for multiline header)
+		    // and used in the next line. But it appears additional logic would be needed further down as well?
                     XElement protoRow = table.Elements(W.tr).Skip(1).FirstOrDefault();
                     var footerRowsBeforeTransform = table
                         .Elements(W.tr)

--- a/OpenXmlPowerTools/PtOpenXmlDocument.cs
+++ b/OpenXmlPowerTools/PtOpenXmlDocument.cs
@@ -132,7 +132,17 @@ namespace OpenXmlPowerTools
         public OpenXmlPowerToolsDocument(string fileName)
         {
             this.FileName = fileName;
-            DocumentByteArray = File.ReadAllBytes(fileName);
+            //DocumentByteArray = File.ReadAllBytes(fileName);
+            // Allow for read of file (e.g. a template) that is open in another application.
+            // May not work against all file opens, but does when a .docx is open in Word
+            using (FileStream fileStream = new FileStream(FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            { 
+                    using (var streamReader = new MemoryStream())
+                    {
+                        fileStream.CopyTo(streamReader);
+                        DocumentByteArray = streamReader.ToArray();
+                    }
+            }
         }
 
         public OpenXmlPowerToolsDocument(string fileName, bool convertToTransitional)


### PR DESCRIPTION
This makes it easier to have a template open for editing.
Make changes in template, run a document assembler program
Repeat as needed until results are as expected.
No need to keep closing the template in between runs.